### PR TITLE
Add POPL'16 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,15 +404,18 @@ In Proceedings of the 2015 ACM SIGPLAN International Conference on Object-Orient
 
 ##### Abstracting Gradual Typing
 Ronald Garcia, Alison M. Clark, Éric Tanter
-POPL 2016, To Appear
+POPL 2016, ACM, New York, NY, USA, 429-442.
+http://dl.acm.org/citation.cfm?id=2837670
 
 ##### The Gradualizer: a methodology and algorithm for generating gradual type systems
 Matteo Cimini, Jeremy Siek
-POPL 2016, To Appear
+POPL 2016, ACM, New York, NY, USA, 443-455.
+http://cimini.info/publications/Gradualizer_Draft.pdf
 
 ##### Is Sound Gradual Typing Dead?
 Asumu Takikawa, Daniel Feltey, Ben Greenman, Max New, Jan Vitek, Matthias Felleisen
-POPL 2016, To Appear
+POPL 2016, ACM, New York, NY, USA, 456-468.
+http://www.ccs.neu.edu/racket/pubs/popl16-tfgnvf.pdf
 
 # Early Work on Interoperation
 

--- a/main.rkt
+++ b/main.rkt
@@ -440,6 +440,34 @@
    #:location (proceedings-location ecoop)
    #:date 2015))
 
+(define tt-oopsla-2015
+  (make-bib
+   #:title "Customizable Gradual Polymorphic Effects for Scala"
+   #:author (authors "Matías Toro" "Éric Tanter")
+   #:location (proceedings-location popl #:pages '(935 953))
+   #:date 2015))
+
+(define gct-popl-2016
+  (make-bib
+   #:title "Abstracting Gradual Typing"
+   #:author (authors "Ronald Garcia" "Alison M. Clark" "Éric Tanter")
+   #:location (proceedings-location popl #:pages '(429 442))
+   #:date 2016))
+
+(define cs-popl-2016
+  (make-bib
+   #:title "The Gradualizer: A methodology and algorithm for generating gradual type systems"
+   #:author (authors "Matteo Cimini" "Jeremy Siek")
+   #:location (proceedings-location popl #:pages '(443 455))
+   #:date 2016))
+
+(define tfgnvf-popl-2016
+  (make-bib
+   #:title "Is Sound Gradual Typing Dead?"
+   #:author (authors "Asumu Takikawa" "Daniel Feltey" "Ben Greenman" "Max New" "Jan Vitek" "Matthias Felleisen")
+   #:location (proceedings-location popl #:pages '(456 468))
+   #:date 2016))
+
 ;; ----------------------------------------
 ; Early Work on Interoperation
 


### PR DESCRIPTION
Are the ACM links ok, or do we want the public ones? (AGT is [open access](http://delivery.acm.org/10.1145/2840000/2837670/p429-garcia.pdf?ip=50.133.137.140&id=2837670&acc=OPEN&key=4D4702B0C3E38B35%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35%2E6D218144511F3437&CFID=747472164&CFTOKEN=74206339&__acm__=1454199637_8c28769c3af88e793c2fad6894659ee9))

http://cimini.info/publications/Gradualizer_Draft.pdf
http://www.ccs.neu.edu/racket/pubs/popl16-tfgnvf.pdf