### PR TITLE
add TS paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,11 @@ POPL '81 Proceedings of the 8th ACM SIGPLAN-SIGACT symposium on Principles of pr
 Norihisa Suzuki and Minoru Terada  
 POPL '84 Proceedings of the 11th ACM SIGACT-SIGPLAN symposium on Principles of programming languages 
 
+##### TS: An Optimizing Compiler for Smalltalk
+Ralph E. Johnson and Justin O. Graver and Lawrence W. Zurawski
+OOPSLA '88: Proceedings of the 3rd annual ACM SIGPLAN Conference on Object Oriented Programming, Systems, Languages, and Applications, pages 18-26.
+http://dl.acm.org/citation.cfm?id=62086
+
 #####  Static type inference in a dynamically typed language
 Alexander Aiken and Brian R. Murphy  
 In POPL ’91: Proceedings of the 18th ACM SIGPLAN-SIGACT Symposium on Principles of Programming Languages, pages 279–290. ACM Press, 1991.

--- a/main.rkt
+++ b/main.rkt
@@ -523,6 +523,13 @@
    #:location (proceedings-location popl #:pages '(290 296))
    #:date 1984))
 
+(define jgz-oopsla-1998
+  (make-bib
+   #:title "TS: An Optimizing Compiler for Smalltalk"
+   #:author (authors "Ralph E. Johnson" "Justin O. Graver" "Lawrence W. Zurawski")
+   #:location (proceedings-location oopsla #:pages '(18 26))
+   #:date 1988))
+
 (define am-popl-1991
   (make-bib
    #:title "Static Type Inference in a Dynamically Typed Language"


### PR DESCRIPTION
Describes an optimizing compiler for a typed version of Smalltalk.
Types are sets of classes. Class types are very structural.
Type annotations are mandatory and a big problem.
Performance is good but the SELF paper claims to do more, much faster.
