### PR TITLE
typo: asplas -> aplas

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -33,7 +33,7 @@
   (define Symposium "Sym. ")
   (define Transactions "Trans. ")
 
-  (define/short asplas "APLAS" (string-append "Asian " Symposium "Programming Languages and Systems"))
+  (define/short aplas "APLAS" (string-append "Asian " Symposium "Programming Languages and Systems"))
   (define/short fpca "FPCA" (string-append ACM International Conference "Functional Programming Languages and Computer Architecture"))
   (define/short icfp "ICFP" (string-append ACM International Conference "Functional Programming"))
   (define/short pldi "PLDI" (string-append ACM Conference "Programming Language Design and Implementation"))


### PR DESCRIPTION
Is this safe to merge, or should we leave the typo to avoid breaking things?

[reference](http://pl.postech.ac.kr/aplas2015/)