### PR TITLE
add complete monitors, oopsla'19

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,11 @@ PLDI 2019, ACM.
 https://doi.org/10.1145/3314221.3314627
 https://akuhlens.github.io/paper/pldi19.pdf
 
+##### Complete Monitors for Gradual Types
+Ben Greenman, Matthias Felleisen, Christos Dimoulas
+OOPSLA 2019, ACM.
+https://doi.org/10.1145/3360548
+
 ##### Gradual C Programming for Typed Lua
 Rafi Shan Turas
 Masters Thesis

--- a/main.rkt
+++ b/main.rkt
@@ -68,7 +68,8 @@
   (define/short icalp "ICALP" (string-append International "Colloquium on Automata, Languages, and Programming"))
   (define/short sac "SAC" (string-append Symposium "on Applied Computing"))
   (define/short snapl "SNAPL" "Summit on Advances in Programming Languages")
-  (define/short dyla "DYLA" (string-append Workshop "on Dynamic Languages and Applications")))
+  (define/short dyla "DYLA" (string-append Workshop "on Dynamic Languages and Applications"))
+  (define/short pacmpl "PACMPL" "Proceedings of the ACM on Programming Languages"))
 
 (require 'util)
 
@@ -476,6 +477,13 @@
    #:author (authors "Asumu Takikawa" "Daniel Feltey" "Ben Greenman" "Max New" "Jan Vitek" "Matthias Felleisen")
    #:location (proceedings-location popl #:pages '(456 468))
    #:date 2016))
+
+(define gfd-oopsla-2019
+  (make-bib
+    #:title "Complete Monitors for Gradual Types"
+    #:author (authors "Ben Greenman" "Matthias Felleisen" "Christos Dimoulas")
+    #:location (journal-location pacmpl #:volume "1" #:number "OOPSLA"  #:pages '(122:1 122:29))
+    #:date 2019))
 
 ;; ----------------------------------------
 ; Early Work on Interoperation


### PR DESCRIPTION
The DOI link isn't up yet. If we want something that works now too, I can add: https://www2.ccs.neu.edu/racket/pubs/oopsla19-gfd.pdf